### PR TITLE
Update socks release to remove ip dependency

### DIFF
--- a/packages/socks-proxy-agent/package.json
+++ b/packages/socks-proxy-agent/package.json
@@ -109,7 +109,7 @@
   "dependencies": {
     "agent-base": "^7.0.2",
     "debug": "^4.3.4",
-    "socks": "^2.7.1"
+    "socks": "^2.7.3"
   },
   "devDependencies": {
     "@types/async-retry": "^1.4.5",


### PR DESCRIPTION
socks 2.7.1 depends on ip 2.0.0 impacted by Critical CVE-2023-42282
socks 2.7.3 removes dependency on ip